### PR TITLE
fix(docker): upgrade Node.js to v22 and fix pnpm version mismatch

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 # Set environment variables
 ENV PNPM_HOME="/pnpm"
@@ -11,8 +11,8 @@ RUN apk add --no-cache libc6-compat && \
     addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001 -G nodejs
 
-# Enable pnpm
-RUN corepack enable
+# Enable pnpm with correct version from package.json
+RUN corepack enable && corepack prepare --activate
 
 WORKDIR /app
 

--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Production Dockerfile for Next.js client
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -10,7 +10,7 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
 RUN \
-  if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && corepack prepare --activate && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -26,7 +26,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN \
-  if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && corepack prepare --activate && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 


### PR DESCRIPTION
## Summary

- Upgraded base Docker image from `node:18-alpine` to `node:22-alpine`
- Added explicit `corepack prepare --activate` after `corepack enable` in both dev and prod Dockerfiles

## Problem

CI builds were failing because Node.js 18's bundled corepack doesn't include pnpm 10.x. The project's `package.json` specifies pnpm 10.3.0, causing a version mismatch error during dependency installation.

## Solution

1. **Upgrade to Node.js 22**: Includes newer corepack with pnpm 10.x support
2. **Explicit activation**: `corepack prepare --activate` ensures the exact pnpm version from package.json is downloaded and activated before use

## Files Changed

- `client/Dockerfile` - Dev environment
- `client/Dockerfile.prod` - Production multi-stage build

## Test Plan

- [ ] Build dev Docker image: `docker build -f client/Dockerfile -t test-dev ./client`
- [ ] Build prod Docker image: `docker build -f client/Dockerfile.prod -t test-prod ./client`
- [ ] Verify pnpm version matches package.json (10.3.0)
- [ ] Test Skaffold deployment: `skaffold dev`
- [ ] Verify frontend starts successfully at http://localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)