### PR TITLE
feat(server): make CORS origins configurable via environment variable

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -83,6 +83,8 @@ env:
     value: "weatherdb"
   DB_USER:
     value: "weather-map@fvh-project-containers-etc.iam"
+  CORS_ORIGINS:
+    value: "https://weather-map.dataportal.fi,http://localhost:3000"
 externalSecret:
   enabled: true
   name: weather-map-secrets

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -26,7 +27,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-origins = ["http://localhost:3000"]
+origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary

This PR adds configuration support for CORS origins via environment variable, enabling the FastAPI server to serve both the production frontend and local development.

### Changes

- **Server (`server/src/main.py`)**: Replace hardcoded CORS origins list with `CORS_ORIGINS` environment variable
  - Falls back to `http://localhost:3000` if not set
  - Parses comma-separated list of origins
- **Deployment (`deploy/server-values.yaml`)**: Add `CORS_ORIGINS` environment variable
  - Production origin: `https://weather-map.dataportal.fi`
  - Development origin: `http://localhost:3000`

### Benefits

- Supports production deployment without code changes
- Maintains local development workflow
- Follows 12-factor app configuration principles
- Allows easy addition of new origins without code modification

### Test Plan

- [ ] Verify local development still works with default CORS settings
- [ ] Confirm production deployment accepts requests from weather-map.dataportal.fi
- [ ] Test that CORS blocks requests from unauthorized origins
- [ ] Validate environment variable parsing handles multiple comma-separated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)