### PR TITLE
fix(server): create weather schema on startup

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "go",
+      "args": ["run", "github.com/github/github-mcp-server/cmd/github-mcp-server@latest", "stdio"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    },
+    "vectorcode": {
+      "command": "uvx",
+      "args": ["vectorcode-mcp"],
+      "env": {
+        "VECTORCODE_INDEX_PATH": "${HOME}/.vectorcode"
+      }
+    },
+    "context7": {
+      "command": "bunx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/server/src/api/database.py
+++ b/server/src/api/database.py
@@ -1,5 +1,6 @@
 import os
 
+from sqlalchemy import text
 from sqlmodel import Session, SQLModel, create_engine
 
 DB_NAME = os.environ.get("DB_NAME", "weatherdb")
@@ -11,6 +12,11 @@ DB_PASS = os.environ.get("DB_PASS", "pass")
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
 engine = create_engine(DATABASE_URL)
+
+# Create the weather schema if it doesn't exist (required for tables)
+with engine.connect() as conn:
+    conn.execute(text("CREATE SCHEMA IF NOT EXISTS weather"))
+    conn.commit()
 
 SQLModel.metadata.create_all(engine)
 


### PR DESCRIPTION
## Summary
- Creates the `weather` schema in Cloud SQL on application startup if it doesn't exist
- Fixes 500 Internal Server Error on `/api/sensors` endpoint caused by missing `weather.sensors` table
- Adds MCP configuration for development tooling

## Root Cause
The SQLModel `create_all()` was trying to create tables in the `weather` schema, but PostgreSQL schemas must be created explicitly. The `weather` schema didn't exist in Cloud SQL, causing the table creation to fail silently, resulting in 500 errors when accessing sensor endpoints.

## Test plan
- [ ] Merge and deploy to verify the schema/tables are created
- [ ] Verify https://weather-map-api.dataportal.fi/api/sensors returns sensor data
- [ ] Verify https://weather-map.dataportal.fi/ loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)