### PR TITLE
ci: add auto-merge workflow for ArgoCD image updater branches

### DIFF
--- a/.github/workflows/auto-merge-image-updater.yml
+++ b/.github/workflows/auto-merge-image-updater.yml
@@ -1,0 +1,50 @@
+name: Auto-merge ArgoCD Image Updater branches
+
+on:
+  push:
+    branches:
+      - "image-updater-**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-and-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Pull Request
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ github.ref_name }}" \
+            --title "chore(deps): update container image" \
+            --body "Automated image update by argocd-image-updater.
+
+          Branch: \`${{ github.ref_name }}\`" \
+            2>&1) || true
+
+          # Check if PR already exists
+          if echo "$PR_URL" | grep -q "already exists"; then
+            PR_URL=$(gh pr view "${{ github.ref_name }}" --json url -q .url)
+          fi
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Created/found PR: $PR_URL"
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "${{ github.ref_name }}"
+        continue-on-error: true
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow to automate PR creation and merge for `image-updater-**` branches
- Workflow creates PR, optionally approves (when `AUTO_MERGE_PAT` secret configured), and enables auto-merge with squash
- Streamlines ArgoCD Image Updater integration by automating the merge process

## Test plan

- [ ] Verify workflow triggers on `image-updater-*` branch push
- [ ] Verify PR is created with correct metadata
- [ ] Verify auto-merge is enabled after PR creation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)