### PR TITLE
fix(client): add defensive error handling for sensors API

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -29,8 +29,16 @@ export interface LatestData {
 }
 
 export default async function Home() {
-  const res = await apiFetch("/sensors");
-  const sensors: Sensor[] = await res.json();
+  let sensors: Sensor[] = [];
+  try {
+    const res = await apiFetch("/sensors");
+    if (res.ok) {
+      const data = await res.json();
+      sensors = Array.isArray(data) ? data : [];
+    }
+  } catch (error) {
+    console.error("Failed to fetch sensors:", error);
+  }
 
   // Get latest data
   let latestData: VallilaLatestData[] = [];


### PR DESCRIPTION
## Summary

- Wrap `/sensors` API call in try-catch block
- Validate response is actually an array before calling `.filter()`
- Initialize `sensors` as empty array to ensure graceful degradation

This fixes a `TypeError: t.filter is not a function` crash that occurred when the backend API was unavailable or returned non-array data.

## Test plan

- [ ] Verify page loads when backend is running
- [ ] Verify page loads gracefully (with empty sensor lists) when backend is unavailable
- [ ] Confirm no TypeErrors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)