### PR TITLE
fix(server): inject DB_PASS secret into container environment

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -84,11 +84,17 @@ env:
     value: "weatherdb"
   DB_USER:
     value: "weather-map@fvh-project-containers-etc.iam"
+  DB_PASS:
+    valueFrom:
+      secretKeyRef:
+        name: weather-map-secrets
+        key: DB_PASS
   CORS_ORIGINS:
     value: "https://weather-map.dataportal.fi,http://localhost:3000"
 externalSecret:
   enabled: true
   name: weather-map-secrets
+  namespace: weather-map
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
## Summary

- Adds `DB_PASS` environment variable referencing the `weather-map-secrets` Kubernetes secret
- Adds explicit `namespace: weather-map` to External Secret configuration

## Problem

The production API at https://weather-map-api.dataportal.fi/api/sensors was returning 500 errors. The External Secret was correctly configured to fetch `DB_PASS` from Google Secret Manager and create a Kubernetes Secret, but **the secret was never being injected into the pod's environment variables**.

The FastAPI server was falling back to the default password value (`pass`) since `DB_PASS` wasn't set.

## Root Cause

Missing `secretKeyRef` configuration in the `env` section of `server-values.yaml`.

## Test Plan

- [ ] ArgoCD syncs the change successfully
- [ ] External Secret creates/updates `weather-map-secrets`
- [ ] Pod restarts with `DB_PASS` environment variable set
- [ ] https://weather-map-api.dataportal.fi/api/sensors returns 200 with sensor data
- [ ] https://weather-map.dataportal.fi loads without JavaScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)