### PR TITLE
fix(server): add security context for Kyverno policy compliance

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -16,6 +16,16 @@ resources:
   requests:
     cpu: 100m
     memory: 256Mi
+# Security context for main container and migration job containers
+# Required by Kyverno policies: disallow-privilege-escalation, require-ro-rootfs
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
 service:
   type: ClusterIP
   port: 8000


### PR DESCRIPTION
## Summary

Adds `securityContext` configuration to satisfy Kyverno security policies that are blocking the migration job.

## Problem

The migration pod was failing with Kyverno policy violations:
- `disallow-privilege-escalation/check-privilege-escalation` - requires `allowPrivilegeEscalation: false`
- `require-ro-rootfs/check-ro-rootfs` - requires `readOnlyRootFilesystem: true`

## Solution

Added security context at the root level of server-values.yaml which applies to:
- Main server container
- Migration job container
- wait-for-database init container

```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 1000
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  capabilities:
    drop:
    - ALL
```

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] Migration job passes Kyverno policies
- [ ] Migrations run successfully
- [ ] Server pod starts and passes health checks
- [ ] https://weather-map-api.dataportal.fi/api/sensors returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)