### PR TITLE
fix(server): set MPLCONFIGDIR to resolve matplotlib config error

### DIFF
--- a/k8s/fastapi-configmap.yaml
+++ b/k8s/fastapi-configmap.yaml
@@ -10,3 +10,4 @@ data:
   DB_HOST: postgres-service
   DB_PORT: "5432"
   DB_USER: postgres
+  MPLCONFIGDIR: /tmp/matplotlib

--- a/k8s/fastapi-deployment.yaml
+++ b/k8s/fastapi-deployment.yaml
@@ -46,6 +46,11 @@ spec:
             secretKeyRef:
               name: fastapi-secret
               key: DB_PASS
+        - name: MPLCONFIGDIR
+          valueFrom:
+            configMapKeyRef:
+              name: fastapi-config
+              key: MPLCONFIGDIR
         resources:
           requests:
             memory: "256Mi"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    MPLCONFIGDIR=/tmp/matplotlib
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -5,7 +5,8 @@ FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    MPLCONFIGDIR=/tmp/matplotlib
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Matplotlib requires a writable config directory but the container runs with a read-only root filesystem. This adds MPLCONFIGDIR=/tmp/matplotlib to both the Kubernetes ConfigMap/Deployment and Dockerfiles.