### PR TITLE
fix(server): add writable /tmp volume for matplotlib cache

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -101,6 +101,15 @@ env:
         key: DB_PASS
   CORS_ORIGINS:
     value: "https://weather-map.dataportal.fi,http://localhost:3000"
+  MPLCONFIGDIR:
+    value: "/tmp/matplotlib"
+# Writable tmp directory for matplotlib cache (required with readOnlyRootFilesystem)
+volumes:
+- name: tmp
+  emptyDir: {}
+volumeMounts:
+- name: tmp
+  mountPath: /tmp
 externalSecret:
   enabled: true
   name: weather-map-secrets


### PR DESCRIPTION
## Summary
- Adds `MPLCONFIGDIR` environment variable pointing to `/tmp/matplotlib`
- Adds `emptyDir` volume mounted at `/tmp` for writable storage

## Problem
The container runs with `readOnlyRootFilesystem: true` (required by Kyverno policies) which prevents matplotlib from creating its cache directory at startup.

Error:
```
OSError: Matplotlib requires access to a writable cache directory, but there was an issue 
with the default path (/tmp/matplotlib), and a temporary directory could not be created
```

## Solution
Mount an `emptyDir` volume at `/tmp` to provide a writable location for matplotlib's cache while maintaining the security benefits of a read-only root filesystem.

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] Pod starts without matplotlib errors
- [ ] API health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)