### PR TITLE
fix(deploy): use released db migration image tag

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -130,7 +130,7 @@ migrations:
   enabled: true
   image:
     repository: ghcr.io/forumviriumhelsinki/weather-map-db
-    tag: "main"
+    tag: "0.2.0"
   command: ['dbmate']
   args: ['up']
   env:


### PR DESCRIPTION
## Summary
- Fix migrations image from `main` tag to `0.2.0` release
- The `main` tag doesn't exist in GHCR, causing migrations to fail silently
- This left the production database without the required `weather.tags` table, resulting in 500 errors on `/api/tags`

## Test plan
- [ ] Verify PR triggers ArgoCD sync
- [ ] Check migration job runs successfully
- [ ] Confirm `/api/tags` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)