### PR TITLE
fix(deploy): disable waitForDatabase for native sidecar compatibility

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -140,12 +140,10 @@ migrations:
     value: /migrations
   - name: DBMATE_NO_DUMP_SCHEMA
     value: 'true'
+  # waitForDatabase disabled - native sidecar (restartPolicy: Always) ensures
+  # cloud-sql-proxy is running before migration container starts
   waitForDatabase:
-    enabled: true
-    host: 127.0.0.1
-    port: 5432
-    user: 'weather-map@fvh-project-containers-etc.iam'
-    timeout: 300
+    enabled: false
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Summary
- Disable `waitForDatabase` in migration job configuration
- The helm-webapp chart places `wait-for-database` initContainer BEFORE user-defined initContainers
- This caused a deadlock: `wait-for-database` tried to connect to `127.0.0.1:5432` before `cloud-sql-proxy` started

## Root Cause
The migration job was stuck at `PodInitializing` because:
1. `wait-for-database` initContainer runs first (per helm-webapp template order)
2. It tries to connect to the database at `127.0.0.1:5432`
3. `cloud-sql-proxy` (which provides that endpoint) hasn't started yet
4. Deadlock - wait-for-database waits forever

## Fix
Disable `waitForDatabase` - the native sidecar pattern (`restartPolicy: Always` on cloud-sql-proxy) ensures the proxy starts before the main migration container runs.

## Test plan
- [ ] Verify migration job starts successfully
- [ ] Confirm database schema is created (`weather.tags` table exists)
- [ ] Test `/api/tags` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)