### PR TITLE
fix(deploy): enable waitForDatabase for migration job

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -140,10 +140,13 @@ migrations:
     value: /migrations
   - name: DBMATE_NO_DUMP_SCHEMA
     value: 'true'
-  # waitForDatabase disabled - native sidecar (restartPolicy: Always) ensures
-  # cloud-sql-proxy is running before migration container starts
+  # waitForDatabase ensures cloud-sql-proxy has time to establish connection
+  # before migrations run (native sidecars start but aren't immediately ready)
   waitForDatabase:
-    enabled: false
+    enabled: true
+    host: "127.0.0.1"
+    port: 5432
+    timeout: 60
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Summary
- Enable waitForDatabase with pg_isready to ensure database connectivity before running dbmate migrations
- Native sidecars start but aren't immediately ready - Cloud SQL Proxy needs time to authenticate

## Root Cause
The migration job fails because the Cloud SQL Proxy sidecar isn't ready when the migrate container starts:
1. Cloud SQL Proxy starts as native sidecar
2. Migrate container starts immediately (doesn't wait for proxy to be ready)
3. Migrate tries to connect to `127.0.0.1:5432` - **connection refused**

## Test plan
- [ ] Merge infrastructure PR first (helm-webapp 0.18.0)
- [ ] Merge this PR
- [ ] Verify migration job succeeds on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)