### PR TITLE
fix(deploy): add user parameter to waitForDatabase

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -146,6 +146,7 @@ migrations:
     enabled: true
     host: "127.0.0.1"
     port: 5432
+    user: "weather-map@fvh-project-containers-etc.iam"
     timeout: 60
   resources:
     limits:


### PR DESCRIPTION
## Summary
- Add `user` parameter to waitForDatabase configuration for pg_isready

## Root Cause
pg_isready was reporting "no attempt" because it needs to know which IAM user to check for. While pg_isready doesn't need a password (works with IAM auth through Cloud SQL Proxy), it does need the user parameter to properly check database connectivity.

## Changes
```yaml
waitForDatabase:
  enabled: true
  host: "127.0.0.1"
  port: 5432
  user: "weather-map@fvh-project-containers-etc.iam"  # Added
  timeout: 60
```

## References
- FVH deployment patterns doc shows user parameter is required for IAM auth
- Django backend pattern example includes user in waitForDatabase config

## Test plan
- [x] Merge infrastructure PR #845 (helm-webapp 0.18.1)
- [ ] Merge this PR
- [ ] Verify migration job succeeds with pg_isready check

🤖 Generated with [Claude Code](https://claude.com/claude-code)