### PR TITLE
fix(deploy): add nginx CORS annotations for error response handling

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -76,6 +76,13 @@ ingress:
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Enable CORS at nginx level to ensure headers are present even for error responses
+    # (e.g., when KEDA scales to 0, nginx returns 503 without backend CORS headers)
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://weather-map.dataportal.fi"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
   hosts:
   - host: weather-map-api.dataportal.fi
     paths:


### PR DESCRIPTION
## Summary

- Add nginx ingress CORS annotations to ensure `Access-Control-Allow-Origin` headers are present even when the backend returns error responses
- When KEDA scales to 0 and nginx returns 503, browsers block the response due to missing CORS headers
- The FastAPI backend already has CORS middleware configured, but nginx generates error responses without CORS headers when the upstream is unavailable

## Root Cause Analysis

The CORS error occurred because:
1. The server uses KEDA to scale to 0 replicas during off-hours
2. When the backend is unavailable, nginx returns 503 errors
3. These error responses don't have CORS headers (since they're generated by nginx, not the FastAPI app)
4. Browsers block these responses due to the missing `Access-Control-Allow-Origin` header

## Changes

Added nginx ingress annotations:
- `nginx.ingress.kubernetes.io/enable-cors: "true"` - Enable CORS at nginx level
- `nginx.ingress.kubernetes.io/cors-allow-origin` - Allow the frontend domain
- `nginx.ingress.kubernetes.io/cors-allow-methods` - Allow GET, POST, OPTIONS
- `nginx.ingress.kubernetes.io/cors-allow-headers` - Standard headers
- `nginx.ingress.kubernetes.io/cors-allow-credentials` - Allow credentials

## Test plan

- [ ] Deploy to staging and verify CORS headers are present in nginx responses
- [ ] Test that preflight OPTIONS requests receive proper CORS headers
- [ ] Verify that error responses (503) include CORS headers when backend is scaled to 0

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)