### PR TITLE
perf(server): further memory optimization for plot generation

### DIFF
--- a/server/src/analysis/fluctuation_and_decomposition_analysis.py
+++ b/server/src/analysis/fluctuation_and_decomposition_analysis.py
@@ -1,139 +1,227 @@
+"""Fluctuation and decomposition analysis for weather sensor data.
+
+This module provides functions for analyzing humidity data patterns using
+FFT (Fast Fourier Transform) and STL (Seasonal-Trend decomposition using LOESS).
+"""
+
+from __future__ import annotations
+
+import gc
 import io
+import logging
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
 from matplotlib import gridspec
 from numpy.fft import fft
 from statsmodels.tsa.seasonal import STL
+
 from utils.get_data_util import get_all_locations
 from utils.utils import map_locations
 
-### This function is used to plot the raw humidity data from all sensors
-def plot_raw_humidity():
-	df = get_all_locations()
-	map_locations()
-	fig = plt.figure(figsize=(20, 10))
-	gs = gridspec.GridSpec(1, 2, width_ratios=[4, 1])
-	ax = fig.add_subplot(gs[0])
-	ax_cb = fig.add_subplot(gs[1])
+if TYPE_CHECKING:
+    pass
 
-	sensor_lines = {}
+logger = logging.getLogger(__name__)
 
-	for sensor_id, sensor_data in df.groupby("dev-id"):
-		(line,) = ax.plot(
-			sensor_data["time"],
-			sensor_data["humidity"],
-			label=sensor_id,
-			alpha=0.7,
-		)
-		sensor_lines[sensor_id] = line
 
-	ax.set_xlabel("Aika")
-	ax.set_ylabel("Ilmankosteus (%)")
-	ax.set_title("Raaka ilmankosteusdata ajan mittaan")
-	ax.tick_params(axis="x", rotation=45)
-	ax.grid(True)
-	ax.legend(title="Sensors", bbox_to_anchor=(1, 1))
+def plot_raw_humidity(df: pd.DataFrame | None = None) -> io.BytesIO:
+    """Plot raw humidity data from all sensors.
 
-	ax_cb.set_xticks([])
-	ax_cb.set_yticks([])
-	ax_cb.set_frame_on(False)
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
 
-	buf = io.BytesIO()
-	plt.savefig(buf, format="png")
-	plt.close()
-	buf.seek(0)
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting raw humidity data...")
+    if df is None:
+        df = get_all_locations()
 
-	return buf
+    map_locations()
+    fig = plt.figure(figsize=(20, 10))
+    gs = gridspec.GridSpec(1, 2, width_ratios=[4, 1])
+    ax = fig.add_subplot(gs[0])
+    ax_cb = fig.add_subplot(gs[1])
 
-## This function is used to plot the FFT analysis of the humidity data. User can specify an area to filter the data.
-## The function uses the Fast Fourier Transform to analyze the frequency components of the humidity data.
-def plot_fft_analysis(area=None):
-	df = get_all_locations()
-	map = map_locations()
+    sensor_lines = {}
 
-	if area:
-		if area not in map:
-			raise ValueError(
-				f"Invalid area: {area}. Valid areas are: {list(map.keys())}"
-			)
-		sensor_ids = map[area]
-		df = df[df["dev-id"].isin(sensor_ids)]
+    for sensor_id, sensor_data in df.groupby("dev-id"):
+        (line,) = ax.plot(
+            sensor_data["time"],
+            sensor_data["humidity"],
+            label=sensor_id,
+            alpha=0.7,
+        )
+        sensor_lines[sensor_id] = line
 
-	df.set_index("time", inplace=True)
-	grouped = df[["dev-id", "humidity"]].groupby("dev-id").resample("D").mean()
-	grouped = grouped.reset_index()
-	grouped["humidity"] = (
-		grouped["humidity"].rolling(window=7, min_periods=1).mean()
-	)
+    ax.set_xlabel("Aika")
+    ax.set_ylabel("Ilmankosteus (%)")
+    ax.set_title("Raaka ilmankosteusdata ajan mittaan")
+    ax.tick_params(axis="x", rotation=45)
+    ax.grid(True)
+    ax.legend(title="Sensors", bbox_to_anchor=(1, 1))
 
-	fig = plt.figure(figsize=(20, 10))
-	gs = gridspec.GridSpec(1, 2, width_ratios=[4, 1])
-	ax = fig.add_subplot(gs[0])
-	ax_cb = fig.add_subplot(gs[1])
+    ax_cb.set_xticks([])
+    ax_cb.set_yticks([])
+    ax_cb.set_frame_on(False)
 
-	sensor_lines = {}
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
 
-	for sensor_id in grouped["dev-id"].unique():
-		sensor_df = grouped[grouped["dev-id"] == sensor_id]
-		humidity_fft = fft(sensor_df["humidity"].dropna())
-		freqs = np.fft.fftfreq(len(humidity_fft))
-		(line,) = ax.plot(
-			freqs[: len(freqs) // 2],
-			np.abs(humidity_fft[: len(freqs) // 2]),
-			label=sensor_id,
-			alpha=0.7,
-		)
-		sensor_lines[sensor_id] = line
+    # Free memory after plot generation
+    del sensor_lines
+    gc.collect()
 
-	ax.set_yscale("log")
-	ax.set_title("Ilmankosteuden FFT-analyysi")
-	ax.set_xlabel("Taajuus (x/1)")
-	ax.set_ylabel("Voimakkuus")
-	ax.grid(True)
-	ax.legend(title="Sensors", bbox_to_anchor=(1, 1))
+    return buf
 
-	ax_cb.set_xticks([])
-	ax_cb.set_yticks([])
-	ax_cb.set_frame_on(False)
 
-	buf = io.BytesIO()
-	plt.savefig(buf, format="png")
-	plt.close()
-	buf.seek(0)
+def plot_fft_analysis(
+    area: str | None = None,
+    df: pd.DataFrame | None = None,
+) -> io.BytesIO:
+    """Plot FFT analysis of humidity data.
 
-	return buf
+    Uses the Fast Fourier Transform to analyze frequency components
+    of the humidity data. User can specify an area to filter the data.
 
-## This function is used to plot the seasonal decomposition of the humidity data using STL (Seasonal-Trend decomposition using LOESS).
-## The function decomposes the time series data into trend, seasonal, and residual components.
-def plot_seasonal_decomposition():
-	df = get_all_locations()
-	print("Columns at start of seasonal decomposition:", df.dtypes)
+    Args:
+        area: Optional area name to filter sensors. If None, uses all sensors.
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
 
-	if "time" not in df.columns:
-		print("Error: 'time' column missing before STL decomposition!")
-		return None
+    Returns:
+        BytesIO buffer containing the PNG image.
 
-	df.set_index("time", inplace=True)
-	df["humidity"] = pd.to_numeric(df["humidity"], errors="coerce")
-	df = df[["humidity"]].resample("h").mean()
-	df["humidity"] = df["humidity"].interpolate(method="time")
-	df = df.dropna()
+    Raises:
+        ValueError: If specified area is not valid.
+    """
+    logger.info(
+        "Plotting FFT analysis%s...", f" for area {area}" if area else ""
+    )
+    if df is None:
+        df = get_all_locations()
 
-	if len(df) < 14:
-		print("Error: Not enough data points for STL decomposition!")
-		return None
+    location_map = map_locations()
 
-	stl = STL(df["humidity"], seasonal=143)
-	result = stl.fit()
+    if area:
+        if area not in location_map:
+            raise ValueError(
+                f"Invalid area: {area}. Valid areas are: {list(location_map.keys())}"
+            )
+        sensor_ids = location_map[area]
+        df = df[df["dev-id"].isin(sensor_ids)]
 
-	fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
-	result.trend.plot(ax=axes[0], title="Trendi")
-	result.seasonal.plot(ax=axes[1], title="Kausiluonteisuus")
-	result.resid.plot(ax=axes[2], title="Jäännös")
-	buf = io.BytesIO()
-	plt.savefig(buf, format="png")
-	plt.close()
-	buf.seek(0)
-	return buf
+    df.set_index("time", inplace=True)
+    grouped = df[["dev-id", "humidity"]].groupby("dev-id").resample("D").mean()
+    grouped = grouped.reset_index()
+    grouped["humidity"] = (
+        grouped["humidity"].rolling(window=7, min_periods=1).mean()
+    )
+
+    # Free original df memory after grouping
+    del df
+    gc.collect()
+
+    fig = plt.figure(figsize=(20, 10))
+    gs = gridspec.GridSpec(1, 2, width_ratios=[4, 1])
+    ax = fig.add_subplot(gs[0])
+    ax_cb = fig.add_subplot(gs[1])
+
+    sensor_lines = {}
+
+    for sensor_id in grouped["dev-id"].unique():
+        sensor_df = grouped[grouped["dev-id"] == sensor_id]
+        humidity_fft = fft(sensor_df["humidity"].dropna())
+        freqs = np.fft.fftfreq(len(humidity_fft))
+        (line,) = ax.plot(
+            freqs[: len(freqs) // 2],
+            np.abs(humidity_fft[: len(freqs) // 2]),
+            label=sensor_id,
+            alpha=0.7,
+        )
+        sensor_lines[sensor_id] = line
+
+    ax.set_yscale("log")
+    ax.set_title("Ilmankosteuden FFT-analyysi")
+    ax.set_xlabel("Taajuus (x/1)")
+    ax.set_ylabel("Voimakkuus")
+    ax.grid(True)
+    ax.legend(title="Sensors", bbox_to_anchor=(1, 1))
+
+    ax_cb.set_xticks([])
+    ax_cb.set_yticks([])
+    ax_cb.set_frame_on(False)
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
+
+    # Free memory after plot generation
+    del grouped, sensor_lines
+    gc.collect()
+
+    return buf
+
+
+def plot_seasonal_decomposition(
+    df: pd.DataFrame | None = None,
+) -> io.BytesIO | None:
+    """Plot seasonal decomposition of humidity data using STL.
+
+    Uses Seasonal-Trend decomposition using LOESS to decompose the time series
+    data into trend, seasonal, and residual components.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image, or None if insufficient data.
+    """
+    logger.info("Plotting seasonal decomposition...")
+    if df is None:
+        df = get_all_locations()
+
+    logger.debug("Columns at start of seasonal decomposition: %s", df.dtypes)
+
+    if "time" not in df.columns:
+        logger.error("'time' column missing before STL decomposition!")
+        return None
+
+    df.set_index("time", inplace=True)
+    df["humidity"] = pd.to_numeric(df["humidity"], errors="coerce")
+    df = df[["humidity"]].resample("h").mean()
+    df["humidity"] = df["humidity"].interpolate(method="time")
+    df = df.dropna()
+
+    min_data_points = 14  # Minimum required for STL decomposition
+    if len(df) < min_data_points:
+        logger.error("Not enough data points for STL decomposition!")
+        return None
+
+    stl = STL(df["humidity"], seasonal=143)
+    result = stl.fit()
+
+    # Free df memory before creating figure
+    del df
+    gc.collect()
+
+    fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
+    result.trend.plot(ax=axes[0], title="Trendi")
+    result.seasonal.plot(ax=axes[1], title="Kausiluonteisuus")
+    result.resid.plot(ax=axes[2], title="Jäännös")
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
+
+    # Free memory after plot generation
+    del result
+    gc.collect()
+
+    return buf

--- a/server/src/analysis/location_analysis.py
+++ b/server/src/analysis/location_analysis.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import gc
 import io
 import logging
 import os
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
@@ -38,20 +40,21 @@ def plot_daily_temperature_range(df: pd.DataFrame | None = None) -> io.BytesIO:
         name="temperature_range"
     )
 
+    # Free original df memory after aggregation
+    del df, grouped
+    gc.collect()
+
     summary = (
         daily_range.groupby("location")["temperature_range"]
         .agg(["mean", "std"])
         .round(2)
     )
-    print(
-        "\n[SUMMARY] Average daily temperature range (°C) with standard deviation:"
-    )
-    print(summary)
-    print(
-        f"\n[INFO] Most dynamic daily temperatures: {summary['mean'].idxmax()}"
+    logger.debug(
+        "Average daily temperature range (°C) with standard deviation: %s",
+        summary.to_dict(),
     )
 
-    plt.figure(figsize=(10, 5))
+    fig = plt.figure(figsize=(10, 5))
     for loc in daily_range["location"].unique():
         subset = daily_range[daily_range["location"] == loc]
         plt.plot(subset["date"], subset["temperature_range"], label=loc)
@@ -64,8 +67,13 @@ def plot_daily_temperature_range(df: pd.DataFrame | None = None) -> io.BytesIO:
     plt.tight_layout()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
-    plt.close()
+    plt.close(fig)
     buf.seek(0)
+
+    # Free memory after plot generation
+    del daily_range
+    gc.collect()
+
     return buf
 
 
@@ -86,18 +94,21 @@ def plot_daily_median_temperature(df: pd.DataFrame | None = None) -> io.BytesIO:
         df.groupby(["location", "date"])["temperature"].median().reset_index()
     )
 
+    # Free original df memory after aggregation
+    del df
+    gc.collect()
+
     summary = (
         daily_median.groupby("location")["temperature"]
         .agg(["mean", "std"])
         .round(2)
     )
-    print(
-        "\n[SUMMARY] Average daily median temperature (°C) with standard deviation:"
+    logger.debug(
+        "Average daily median temperature (°C) with standard deviation: %s",
+        summary.to_dict(),
     )
-    print(summary)
-    print(f"\n[INFO] Warmest area on average: {summary['mean'].idxmax()}")
 
-    plt.figure(figsize=(10, 5))
+    fig = plt.figure(figsize=(10, 5))
     for loc in daily_median["location"].unique():
         subset = daily_median[daily_median["location"] == loc]
         plt.plot(subset["date"], subset["temperature"], label=loc)
@@ -110,8 +121,13 @@ def plot_daily_median_temperature(df: pd.DataFrame | None = None) -> io.BytesIO:
     plt.tight_layout()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
-    plt.close()
+    plt.close(fig)
     buf.seek(0)
+
+    # Free memory after plot generation
+    del daily_median
+    gc.collect()
+
     return buf
 
 
@@ -172,8 +188,17 @@ def plot_day_night_temperature_difference(
 def plot_monthly_night_temperature(
     df: pd.DataFrame | None = None,
 ) -> io.BytesIO:
-    print("[INFO] Plotting monthly night-time median temperature...")
-    df = get_all_locations()
+    """Plot monthly night-time median temperature by location.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting monthly night-time median temperature...")
+    if df is None:
+        df = get_all_locations()
     df = df[df["time"].dt.to_period("M") != pd.Period("2025-05", freq="M")]
     df["month"] = df["time"].dt.tz_convert(None).dt.to_period("M")
     df = add_daypart_column(df)
@@ -208,7 +233,6 @@ def plot_monthly_night_temperature(
     plt.xticks(rotation=0)
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -216,9 +240,20 @@ def plot_monthly_night_temperature(
     return buf
 
 
-def plot_monthly_night_min_temperature():
-    print("[INFO] Plotting monthly night-time minimum temperatures...")
-    df = get_all_locations()
+def plot_monthly_night_min_temperature(
+    df: pd.DataFrame | None = None,
+) -> io.BytesIO:
+    """Plot monthly night-time minimum temperature by location.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting monthly night-time minimum temperatures...")
+    if df is None:
+        df = get_all_locations()
     df = df[df["time"].dt.to_period("M") != pd.Period("2025-05", freq="M")]
     df["month"] = df["time"].dt.tz_convert(None).dt.to_period("M")
     df = add_daypart_column(df)
@@ -256,7 +291,6 @@ def plot_monthly_night_min_temperature():
     print("\n[SUMMARY] Average monthly minimum night-time temperature (°C):")
     print(summary.sort_values(ascending=False))
     print(f"\n[INFO] Warmest night minimums on average: {summary.idxmax()}")
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -264,11 +298,25 @@ def plot_monthly_night_min_temperature():
     return buf
 
 
-def plot_monthly_night_temperature_difference(reference_location="Laajasalo"):
-    print(
-        "[INFO] Plotting monthly night-time temperature differences (compared to Laajasalo)..."
+def plot_monthly_night_temperature_difference(
+    reference_location: str = "Laajasalo",
+    df: pd.DataFrame | None = None,
+) -> io.BytesIO | None:
+    """Plot monthly night-time temperature difference compared to reference location.
+
+    Args:
+        reference_location: Location to compare against. Defaults to "Laajasalo".
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image, or None if insufficient data.
+    """
+    logger.info(
+        "Plotting monthly night-time temperature differences (compared to %s)...",
+        reference_location,
     )
-    df = get_all_locations()
+    if df is None:
+        df = get_all_locations()
     df = df[df["time"].dt.to_period("M") != pd.Period("2025-05", freq="M")]
     df["month"] = df["time"].dt.tz_convert(None).dt.to_period("M")
     df = add_daypart_column(df)
@@ -316,7 +364,6 @@ def plot_monthly_night_temperature_difference(reference_location="Laajasalo"):
     plt.grid(axis="y")
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -329,9 +376,18 @@ def plot_monthly_night_temperature_difference(reference_location="Laajasalo"):
 # --------------------------
 
 
-def plot_daily_median_humidity():
-    print("[INFO] Plotting daily median humidity...")
-    df = get_all_locations()
+def plot_daily_median_humidity(df: pd.DataFrame | None = None) -> io.BytesIO:
+    """Plot daily median humidity by location.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting daily median humidity...")
+    if df is None:
+        df = get_all_locations()
     df["date"] = df["time"].dt.date
     daily_median = (
         df.groupby(["location", "date"])["humidity"].median().reset_index()
@@ -358,7 +414,6 @@ def plot_daily_median_humidity():
     plt.grid(axis="y")
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -366,9 +421,18 @@ def plot_daily_median_humidity():
     return buf
 
 
-def plot_daily_humidity_range():
-    print("[INFO] Plotting daily humidity range...")
-    df = get_all_locations()
+def plot_daily_humidity_range(df: pd.DataFrame | None = None) -> io.BytesIO:
+    """Plot daily humidity range by location.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting daily humidity range...")
+    if df is None:
+        df = get_all_locations()
     df["date"] = df["time"].dt.date
     grouped = df.groupby(["location", "date"])["humidity"]
     daily_range = (grouped.max() - grouped.min()).reset_index(
@@ -396,7 +460,6 @@ def plot_daily_humidity_range():
     plt.grid(axis="y")
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -404,9 +467,20 @@ def plot_daily_humidity_range():
     return buf
 
 
-def plot_day_night_humidity_difference():
-    print("[INFO] Plotting day-night humidity difference (monthly)...")
-    df = get_all_locations()
+def plot_day_night_humidity_difference(
+    df: pd.DataFrame | None = None,
+) -> io.BytesIO:
+    """Plot day-night humidity difference by month.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting day-night humidity difference (monthly)...")
+    if df is None:
+        df = get_all_locations()
     df = df[df["time"].dt.to_period("M") != pd.Period("2025-05", freq="M")]
     df = add_daypart_column(df)
 
@@ -437,7 +511,6 @@ def plot_day_night_humidity_difference():
     plt.xticks(rotation=0)
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -445,9 +518,18 @@ def plot_day_night_humidity_difference():
     return buf
 
 
-def plot_monthly_night_humidity():
-    print("[INFO] Plotting monthly night-time median humidity...")
-    df = get_all_locations()
+def plot_monthly_night_humidity(df: pd.DataFrame | None = None) -> io.BytesIO:
+    """Plot monthly night-time median humidity by location.
+
+    Args:
+        df: Optional pre-loaded DataFrame. If None, loads data via get_all_locations().
+
+    Returns:
+        BytesIO buffer containing the PNG image.
+    """
+    logger.info("Plotting monthly night-time median humidity...")
+    if df is None:
+        df = get_all_locations()
     df = df[df["time"].dt.to_period("M") != pd.Period("2025-05", freq="M")]
     df["month"] = df["time"].dt.tz_convert(None).dt.to_period("M")
     df = add_daypart_column(df)
@@ -484,7 +566,6 @@ def plot_monthly_night_humidity():
     plt.xticks(rotation=0)
     plt.legend()
     plt.tight_layout()
-    plt.show()
     buf = io.BytesIO()
     plt.savefig(buf, format="png")
     plt.close()
@@ -497,7 +578,14 @@ def plot_monthly_night_humidity():
 # --------------------------
 
 
-def load_daylight_data():
+@lru_cache(maxsize=1)
+def load_daylight_data() -> pd.DataFrame:
+    """Load and cache daylight data (sunrise/sunset times).
+
+    Uses LRU cache to avoid re-parsing CSV files on every call.
+    Cache is cleared when clear_daylight_cache() is called.
+    """
+    logger.debug("Loading daylight data from CSV files")
     base_dir = os.path.dirname(__file__)
     daylight_24_path = os.path.join(base_dir, "daylight.csv")
     daylight_25_path = os.path.join(base_dir, "daylight25.csv")
@@ -512,8 +600,13 @@ def load_daylight_data():
         df["sunset"] = pd.to_datetime(df["sunset"], format=datetime_format)
         df["date"] = df["sunrise"].dt.date
 
-    daylight_df = pd.concat([daylight_24, daylight_25], ignore_index=True)
-    return daylight_df
+    return pd.concat([daylight_24, daylight_25], ignore_index=True)
+
+
+def clear_daylight_cache() -> None:
+    """Clear the daylight data cache. Useful for testing or memory management."""
+    load_daylight_data.cache_clear()
+    logger.info("Daylight cache cleared")
 
 
 def add_daypart_column(df):

--- a/server/src/tests/test_memory_usage.py
+++ b/server/src/tests/test_memory_usage.py
@@ -115,9 +115,13 @@ class TestDataLoadingMemory:
 
         result, peak_memory = measure_peak_memory(get_all_locations)
 
-        print(f"\nget_all_locations() peak memory: {bytes_to_mb(peak_memory):.1f}MB")
+        print(
+            f"\nget_all_locations() peak memory: {bytes_to_mb(peak_memory):.1f}MB"
+        )
         print(f"DataFrame shape: {result.shape}")
-        print(f"DataFrame memory: {result.memory_usage(deep=True).sum() / 1024 / 1024:.1f}MB")
+        print(
+            f"DataFrame memory: {result.memory_usage(deep=True).sum() / 1024 / 1024:.1f}MB"
+        )
 
         assert peak_memory < MEMORY_LIMIT_BYTES, (
             f"get_all_locations used {bytes_to_mb(peak_memory):.1f}MB, "
@@ -129,7 +133,6 @@ class TestMemoryTargets:
     """Tests with stricter memory targets for optimized code."""
 
     @pytest.mark.slow
-    @pytest.mark.xfail(reason="Target for optimized implementation")
     def test_fft_plot_optimized_target(self):
         """FFT plot should use less than 256MB after optimization."""
         from analysis import fluctuation_and_decomposition_analysis
@@ -143,27 +146,128 @@ class TestMemoryTargets:
             f"target is {bytes_to_mb(MEMORY_TARGET_BYTES):.1f}MB"
         )
 
+    @pytest.mark.slow
+    def test_daylight_data_caching(self):
+        """Daylight data should be cached and not reload on each call."""
+        import gc
+
+        from analysis.location_analysis import load_daylight_data
+
+        gc.collect()
+        tracemalloc.start()
+
+        # First call loads data
+        df1 = load_daylight_data()
+        _, first_peak = tracemalloc.get_traced_memory()
+
+        # Second call should use cache (minimal memory allocation)
+        tracemalloc.reset_peak()
+        df2 = load_daylight_data()
+        _, second_peak = tracemalloc.get_traced_memory()
+
+        tracemalloc.stop()
+
+        # Both should return same data
+        assert df1.equals(df2), "Cached data should be identical"
+
+        # Second call should use significantly less memory (cache hit)
+        # Allow some overhead but expect < 10% of first call
+        max_cache_hit_memory = first_peak * 0.1
+        assert second_peak < max_cache_hit_memory, (
+            f"Cache hit used {bytes_to_mb(second_peak):.1f}MB, "
+            f"expected < {bytes_to_mb(max_cache_hit_memory):.1f}MB (10% of first call)"
+        )
+
+    @pytest.mark.slow
+    def test_filter_install_date_memory_efficiency(self):
+        """filter_install_date should not create excessive intermediate DataFrames."""
+        from utils.get_data_util import filter_install_date, get_rest
+
+        # Load test data
+        df = get_rest(get_2024=True)
+        initial_size = df.memory_usage(deep=True).sum()
+
+        gc.collect()
+        tracemalloc.start()
+
+        filter_install_date(df, "Laajasalo")
+
+        _, peak_memory = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # Peak memory should not exceed 3x the input DataFrame size
+        # (1x for input, 1x for output, 1x for intermediate operations)
+        max_allowed = initial_size * 3
+        assert peak_memory < max_allowed, (
+            f"filter_install_date peak memory {bytes_to_mb(peak_memory):.1f}MB "
+            f"exceeded 3x input size ({bytes_to_mb(max_allowed):.1f}MB)"
+        )
+
+    @pytest.mark.slow
+    def test_all_plot_functions_under_target(self):
+        """All plot functions should stay under 256MB target."""
+        from analysis import location_analysis
+
+        # Functions that should be optimized
+        plot_functions = [
+            (
+                "plot_daily_temperature_range",
+                location_analysis.plot_daily_temperature_range,
+            ),
+            (
+                "plot_daily_median_temperature",
+                location_analysis.plot_daily_median_temperature,
+            ),
+        ]
+
+        failures = []
+        for name, func in plot_functions:
+            result, peak_memory = measure_peak_memory(func)
+            if peak_memory >= MEMORY_TARGET_BYTES:
+                failures.append(
+                    f"{name}: {bytes_to_mb(peak_memory):.1f}MB "
+                    f"(target: {bytes_to_mb(MEMORY_TARGET_BYTES):.1f}MB)"
+                )
+
+        assert not failures, "Functions exceeding 256MB target:\n" + "\n".join(
+            failures
+        )
+
 
 if __name__ == "__main__":
     # Quick profiling script when run directly
     print("Memory Profiling Report")
     print("=" * 50)
 
-    from analysis import fluctuation_and_decomposition_analysis, location_analysis
+    from analysis import (
+        fluctuation_and_decomposition_analysis,
+        location_analysis,
+    )
     from utils.get_data_util import get_all_locations
 
     tests = [
         ("get_all_locations", get_all_locations),
-        ("plot_fft_analysis", fluctuation_and_decomposition_analysis.plot_fft_analysis),
-        ("plot_raw_humidity", fluctuation_and_decomposition_analysis.plot_raw_humidity),
-        ("plot_daily_temperature_range", location_analysis.plot_daily_temperature_range),
+        (
+            "plot_fft_analysis",
+            fluctuation_and_decomposition_analysis.plot_fft_analysis,
+        ),
+        (
+            "plot_raw_humidity",
+            fluctuation_and_decomposition_analysis.plot_raw_humidity,
+        ),
+        (
+            "plot_daily_temperature_range",
+            location_analysis.plot_daily_temperature_range,
+        ),
     ]
 
     for name, func in tests:
         print(f"\nTesting: {name}")
         try:
             result, peak_memory = measure_peak_memory(func)
-            status = "✅ PASS" if peak_memory < MEMORY_LIMIT_BYTES else "❌ FAIL"
+            status = (
+                "✅ PASS" if peak_memory < MEMORY_LIMIT_BYTES else "❌ FAIL"
+            )
             print(f"  Peak memory: {bytes_to_mb(peak_memory):.1f}MB {status}")
         except Exception as e:
             print(f"  ❌ ERROR: {e}")

--- a/server/src/utils/get_data_util.py
+++ b/server/src/utils/get_data_util.py
@@ -242,7 +242,10 @@ def clear_parquet_cache() -> None:
 
 
 def filter_install_date(df: pd.DataFrame, location: str) -> pd.DataFrame:
-    """Filters sensors by location and removes invalid data before install date
+    """Filters sensors by location and removes invalid data before install date.
+
+    Uses vectorized operations instead of sensor-by-sensor filtering for
+    better memory efficiency and performance.
 
     Args:
         df (pandas.DataFrame): Dataframe of fetched data from bri3
@@ -252,7 +255,7 @@ def filter_install_date(df: pd.DataFrame, location: str) -> pd.DataFrame:
         pandas.DataFrame: Dataframe which includes only sensors
         of the specified location with corrected install date
     """
-    # Get ids and install dates
+    # Get ids and install dates from database
     for db in get_session():
         res = db.exec(
             select(Sensor.id, Sensor.install_date).where(
@@ -260,15 +263,30 @@ def filter_install_date(df: pd.DataFrame, location: str) -> pd.DataFrame:
             )
         ).all()
 
-    dfs = []
+    if not res:
+        logger.warning("No sensors found for location: %s", location)
+        return df.iloc[0:0]  # Return empty DataFrame with same columns
 
-    # Mask out data before install dates
-    for sensor_id, install_date in res:
-        mask = df["time"] >= str(install_date)
-        filtered_df = df[(df["dev-id"] == sensor_id) & mask]
-        dfs.append(filtered_df)
+    # Create a mapping of sensor_id -> install_date for vectorized lookup
+    sensor_dates = {
+        sensor_id: pd.Timestamp(install_date) for sensor_id, install_date in res
+    }
+    sensor_ids = set(sensor_dates.keys())
 
-    return pd.concat(dfs)
+    # Filter to only sensors in this location (single boolean mask)
+    location_mask = df["dev-id"].isin(sensor_ids)
+    df_location = df[location_mask]
+
+    if df_location.empty:
+        logger.warning("No data found for sensors in location: %s", location)
+        return df_location
+
+    # Map each row's sensor_id to its install_date, then compare with time
+    # This is a vectorized operation - much faster than looping
+    install_dates = df_location["dev-id"].map(sensor_dates)
+    valid_mask = df_location["time"] >= install_dates
+
+    return df_location[valid_mask]
 
 
 def get_rest(


### PR DESCRIPTION
## Summary

- Adds LRU cache to `load_daylight_data()` to eliminate redundant CSV parsing
- Vectorizes `filter_install_date()` to avoid sensor-by-sensor DataFrame loops
- Removes blocking `plt.show()` calls from all plot functions
- Adds optional `df` parameter to all plot functions for data reuse across multiple plots
- Adds explicit `gc.collect()` calls after data aggregation and plot generation
- Deletes intermediate DataFrames immediately after they are no longer needed

## Test plan

- [x] Run memory profiling tests: `pytest -m slow server/src/tests/test_memory_usage.py`
- [ ] Verify plot endpoints complete without OOM in production
- [ ] Monitor memory usage stays under 512Mi limit

## Technical details

### Daylight data caching
The `load_daylight_data()` function is now decorated with `@lru_cache(maxsize=1)`, eliminating ~1MB of memory per plot that requires daylight filtering (day/night temperature comparisons).

### Vectorized install date filtering
Before: O(n) loop creating n separate DataFrames, then concatenating them
After: Single vectorized operation using `Series.map()` and boolean masking

### Early memory cleanup
- Delete source DataFrames after aggregation but before matplotlib figure creation
- Pass figure reference to `plt.close(fig)` instead of `plt.close()` to ensure cleanup
- Call `gc.collect()` to force immediate memory release

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)