### PR TITLE
build(container): upgrade base images and add security scanning

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,11 +69,28 @@ jobs:
             NEXT_PUBLIC_PYTHON_API=${{ secrets.NEXT_PUBLIC_PYTHON_API }}
             NEXT_PUBLIC_CLIENT_API=${{ secrets.NEXT_PUBLIC_CLIENT_API }}
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        if: github.event_name != 'pull_request'
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-client:${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-client-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.event_name != 'pull_request'
+        with:
+          sarif_file: 'trivy-client-results.sarif'
+          category: 'container-client'
+
   build-server:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -119,11 +137,28 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        if: github.event_name != 'pull_request'
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-server:${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-server-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.event_name != 'pull_request'
+        with:
+          sarif_file: 'trivy-server-results.sarif'
+          category: 'container-server'
+
   build-db:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -169,3 +204,19 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        if: github.event_name != 'pull_request'
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-db:${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-db-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.event_name != 'pull_request'
+        with:
+          sarif_file: 'trivy-db-results.sarif'
+          category: 'container-db'

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 # Set environment variables
 ENV PNPM_HOME="/pnpm"
@@ -11,19 +11,19 @@ RUN apk add --no-cache libc6-compat && \
     addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001 -G nodejs
 
-# Enable pnpm with correct version from package.json
-RUN corepack enable && corepack prepare --activate
-
 WORKDIR /app
 
+# Copy package files first (needed for corepack to detect pnpm version)
+COPY package.json pnpm-lock.yaml ./
+
+# Enable pnpm with correct version from package.json (must run as root)
+RUN corepack enable pnpm && corepack prepare --activate
+
 # Change ownership of the working directory
-RUN chown nextjs:nodejs /app
+RUN chown -R nextjs:nodejs /app
 
 # Switch to non-root user for dependency installation
 USER nextjs
-
-# Copy package files
-COPY --chown=nextjs:nodejs package.json pnpm-lock.yaml ./
 
 # Install dependencies (allow lockfile updates in development)
 RUN pnpm install --no-frozen-lockfile

--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Production Dockerfile for Next.js client
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/db/.dockerignore
+++ b/db/.dockerignore
@@ -1,0 +1,32 @@
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github
+.gitlab-ci.yml
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Docker
+Dockerfile*
+docker-compose*
+compose.y*ml
+
+# Documentation
+*.md
+
+# Temporary
+tmp
+temp
+*.tmp
+*.log
+*.bak
+
+# Secrets
+secrets.dev.yaml
+values.dev.yaml

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,63 @@
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github
+.gitlab-ci.yml
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.venv
+venv
+env
+.env
+.env.*
+*.egg-info
+.eggs
+dist
+build
+*.egg
+
+# Testing
+.pytest_cache
+.coverage
+htmlcov
+.tox
+.nox
+
+# Documentation
+docs
+*.md
+!README.md
+
+# Docker
+Dockerfile*
+docker-compose*
+compose.y*ml
+
+# Kubernetes/Skaffold
+k8s
+skaffold.yaml
+charts
+
+# Temporary
+tmp
+temp
+*.tmp
+*.log
+*.bak
+
+# Secrets
+secrets.dev.yaml
+values.dev.yaml

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -1,17 +1,28 @@
 # Production Dockerfile for FastAPI server
-FROM python:3.11-slim AS base
+# Multi-stage build for minimal image size
+
+# Build stage - install dependencies with build tools
+FROM python:3.13-slim AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir --target=/app/deps -r requirements.txt
+
+# Runtime stage - minimal image without build tools
+FROM python:3.13-slim AS runtime
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONPATH=/app/deps:/app \
     MPLCONFIGDIR=/tmp/matplotlib
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,9 +30,8 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 python && \
     adduser --system --uid 1001 --gid 1001 python
 
-# Copy requirements and install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-deps -r requirements.txt
+# Copy installed dependencies from builder
+COPY --from=builder /app/deps /app/deps
 
 # Copy source code
 COPY --chown=python:python . .
@@ -33,6 +43,6 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/health', timeout=3)" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=3)" || exit 1
 
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

- Upgrade Node.js from 22-alpine to 24-alpine (current LTS)
- Upgrade Python from 3.11-slim to 3.13-slim
- Add Trivy vulnerability scanning to container-build workflow with SARIF upload to GitHub Security tab
- Convert server/Dockerfile.prod to multi-stage build for smaller images (removes gcc from runtime)
- Add .dockerignore files for server/ and db/ directories
- Fix corepack ordering in client Dockerfile for Node 24 compatibility

## Changes

| File | Change |
|------|--------|
| `.github/workflows/container-build.yml` | Added Trivy scanning for all 3 containers |
| `server/Dockerfile` | Python 3.11 → 3.13 |
| `server/Dockerfile.prod` | Python 3.11 → 3.13, multi-stage build |
| `client/Dockerfile` | Node 22 → 24, fixed corepack ordering |
| `client/Dockerfile.prod` | Node 22 → 24 |
| `server/.dockerignore` | Created |
| `db/.dockerignore` | Created |

## Test plan

- [x] `skaffold build` passes locally
- [ ] CI container builds succeed
- [ ] Trivy scan results appear in GitHub Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)