### PR TITLE
fix(server): increase memory limit to 1Gi to prevent OOM kills

### DIFF
--- a/deploy/server-values.yaml
+++ b/deploy/server-values.yaml
@@ -12,7 +12,7 @@ serviceAccount:
 resources:
   limits:
     cpu: 500m
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 100m
     memory: 256Mi

--- a/k8s/fastapi-deployment.yaml
+++ b/k8s/fastapi-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             memory: "256Mi"
             cpu: "250m"
           limits:
-            memory: "512Mi"
+            memory: "1Gi"
             cpu: "500m"
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- Increase FastAPI server memory limit from 512Mi to 1Gi to prevent OOM kills

## Test plan
- [ ] Deploy and monitor for OOM events
- [ ] Check pod memory usage under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)