### PR TITLE
perf(server): reduce memory footprint in parquet data loading

### DIFF
--- a/server/src/utils/get_data_util.py
+++ b/server/src/utils/get_data_util.py
@@ -186,12 +186,13 @@ def get_all_locations(
         dfV = get_vallila()
         dfR = get_rest()
 
-    # filter_install_date already creates new DataFrames via pd.concat,
-    # so no need for .copy() before filtering - this saves ~200MB memory
-    dfK = filter_install_date(dfR, "Koivukyla")
+    # filter_install_date returns boolean-indexed views, so we need .copy()
+    # to safely add the location column without SettingWithCopyWarning.
+    # Memory is freed when dfR is deleted before the final concat.
+    dfK = filter_install_date(dfR, "Koivukyla").copy()
     dfK["location"] = "Koivukyla"
 
-    dfL = filter_install_date(dfR, "Laajasalo")
+    dfL = filter_install_date(dfR, "Laajasalo").copy()
     dfL["location"] = "Laajasalo"
 
     # Delete dfR to free memory before concat
@@ -228,9 +229,9 @@ def read_and_clean_parquet(url: str) -> pd.DataFrame:
     Returns:
         pandas.DataFrame: Dataframe of parquet data
     """
-    # Use cached fetch to avoid re-downloading
-    df = _fetch_parquet_cached(url).copy()
-    df = df.rename_axis("time").reset_index()
+    # No .copy() needed - reset_index() returns a new DataFrame,
+    # so modifications here don't affect the cached data
+    df = _fetch_parquet_cached(url).rename_axis("time").reset_index()
     df["time"] = pd.to_datetime(df["time"])
     return df
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `.copy()` in `read_and_clean_parquet` since `reset_index()` already returns a new DataFrame
- Add required `.copy()` in `get_all_locations` after filtering to fix SettingWithCopyWarning
- Fix incorrect comment about `filter_install_date` behavior

## Memory Impact
Before: 4 full DataFrame copies created unnecessarily in `read_and_clean_parquet`
After: Only 2 smaller filtered subset copies where actually needed

This addresses OOM kills seen when loading all parquet files for FFT analysis.

## Test plan
- [ ] Deploy to staging and trigger `/api/plot/fft` endpoint
- [ ] Monitor memory usage during parquet loading
- [ ] Verify no SettingWithCopyWarning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)