### PR TITLE
refactor(ci): migrate auto-merge workflow to reusable caller

### DIFF
--- a/.github/workflows/auto-merge-image-updater.yml
+++ b/.github/workflows/auto-merge-image-updater.yml
@@ -1,30 +1,12 @@
-# Auto-merges pull requests created by ArgoCD Image Updater.
-# Approves the PR using AUTO_MERGE_PAT (or GITHUB_TOKEN fallback),
-# then enables auto-merge so it lands once status checks pass.
 name: Auto-merge image updater PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-
-permissions:
-  contents: write
-  pull-requests: write
+  push:
+    branches:
+      - 'image-updater-**'
 
 jobs:
   auto-merge:
-    if: startsWith(github.head_ref, 'image-updater/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Approve PR
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
-        run: gh pr review "${{ github.event.pull_request.number }}" --approve
-
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash --base main
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-auto-merge-image-updater.yml@main
+    secrets:
+      AUTO_MERGE_PAT: ${{ secrets.AUTO_MERGE_PAT }}


### PR DESCRIPTION
## Summary
- Replaces standalone `auto-merge-image-updater.yml` with a caller to the org-level reusable workflow
- Changes trigger from `pull_request` to `push` on `image-updater-**` branches (correct pattern per reusable workflow design, avoids GITHUB_TOKEN anti-recursion)
- Reduces maintenance burden — workflow logic is centralized in `.github` repo

## Test plan
- [ ] Wait for next ArgoCD Image Updater push or trigger manually
- [ ] Verify PR creation and auto-merge behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)